### PR TITLE
TurkishDateTimeFormatBugFix

### DIFF
--- a/Seq.App.EventTimeout/EventTimeoutReactor.cs
+++ b/Seq.App.EventTimeout/EventTimeoutReactor.cs
@@ -997,6 +997,8 @@ namespace Seq.App.EventTimeout
         /// <param name="isUpdateHolidays"></param>
         public void UtcRollover(DateTime utcDate, bool isUpdateHolidays = false)
         {
+            if(System.Threading.Thread.CurrentThread.CurrentCulture.Name == "tr-TR")
+                CultureInfo.DefaultThreadCurrentCulture = CultureInfo.CreateSpecificCulture("en-US");
             LogEvent(LogEventLevel.Debug, "UTC Time is currently {UtcTime} ...", Config.UseTestOverrideTime
                 ? Config.TestOverrideTime.ToUniversalTime().ToShortTimeString()
                 : DateTime.Now.ToUniversalTime().ToShortTimeString());


### PR DESCRIPTION
DLL "Lurgle.Dates" threw exception in Turkish Localization.

App host failed unexpectedly

System.FormatException: String '2023-Eyl-08 0:00:00' was not recognized as a valid DateTime.
   at System.DateTimeParse.ParseExact(ReadOnlySpan`1 s, ReadOnlySpan`1 format, DateTimeFormatInfo dtfi, DateTimeStyles style)
   at System.DateTime.ParseExact(String s, String format, IFormatProvider provider, DateTimeStyles style)
   at Lurgle.Dates.Dates.ParseUtcIntervalDate(DateTime sourceDate, String scheduleTime, String timeFormat)
   at Seq.App.EventTimeout.EventTimeoutReactor.UtcRollover(DateTime utcDate, Boolean isUpdateHolidays)
   at Seq.App.EventTimeout.EventTimeoutReactor.OnAttached()
   at Seq.Apps.SeqApp.Attach(IAppHost host)

